### PR TITLE
Fix watch process do not being terminated

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ module.exports = (api, options) => {
     ;['SIGINT', 'SIGTERM'].forEach(signal => {
       process.on(signal, () => {
         server.exit()
+        process.exit(0)
       })
     })
 
@@ -135,6 +136,7 @@ module.exports = (api, options) => {
         if (data.toString() === 'close') {
           console.log('got close signal!')
           server.exit()
+          process.exit(0)
         }
       })
     }


### PR DESCRIPTION
In my case, every time I close serve:bs command by clicking Ctrl+C, the watcher keep running in background.